### PR TITLE
Correct some mistakes

### DIFF
--- a/locale/core.js
+++ b/locale/core.js
@@ -18,7 +18,7 @@ function processRelativeTime(number, withoutSuffix, key, isFuture) {
 
 moment.locale('de', {
   months : 'Januar_Februar_März_April_Mai_Juni_Juli_August_September_Oktober_November_Dezember'.split('_'),
-  monthsShort : 'Jan._Febr._Mrz._Apr._Mai_Jun._Jul._Aug._Sept._Okt._Nov._Dez.'.split('_'),
+  monthsShort : 'Jan._Febr._März_Apr._Mai_Juni_Juli_Aug._Sept._Okt._Nov._Dez.'.split('_'),
   weekdays : 'Sonntag_Montag_Dienstag_Mittwoch_Donnerstag_Freitag_Samstag'.split('_'),
   weekdaysShort : 'So._Mo._Di._Mi._Do._Fr._Sa.'.split('_'),
   weekdaysMin : 'So_Mo_Di_Mi_Do_Fr_Sa'.split('_'),

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -8,15 +8,15 @@ core:
   bio_placeholder: Schreibe etwas über dich...
   cannot_reply: Kann nicht antworten
   cannot_reply_help: Du hast nicht die nötigen Rechte um hier zu antworten.
-  change_email: E-mail ändern
+  change_email: E-Mail ändern
   change_password: Passwort ändern
-  change_password_help: Benutze den folgenden Link und schaue in deiner E-mail nach einem Link um dein Passwort zu ändern.
+  change_password_help: Benutze den folgenden Link und schaue in deiner E-Mail nach einem Link um dein Passwort zu ändern.
   close: Schließen
   confirm_delete_discussion: Willst du diese Diskussion wirklich schließen?
   confirm_discard_discussion: Du hast diese Diskussion noch nicht gepostet. Wirklich verwerfen?
   confirm_discard_edit: Änderungen wurden noch nicht übernommen. Wirklich schließen?
   confirm_discard_reply: Antwort wurde noch nicht gepostet. Wirklich vewerfen?
-  confirmation_email_sent: "Wir haben eine E-mail nach {email} geschickt. Bitte schaue in deinem Spam Ordner nach falls nichts ankommen sollte."
+  confirmation_email_sent: "Wir haben eine E-Mail nach {email} geschickt. Bitte schaue in deinem Spam Ordner nach falls nichts ankommen sollte."
   controls: Einstellungen
   delete: Löschen
   delete_forever: Für immer löschen
@@ -30,11 +30,11 @@ core:
   discussions: Diskussionen
   edit: Ändern
   editing_post: "Beitrag #{number} in {discussion}"
-  email: E-mail
-  email_confirmation_required: "Du musst deine E-mail bestätigen bevor du dich einloggen kannst. Bitte schau in deinem Spam Ordner nach falls nichts ankommen sollte."
+  email: E-Mail
+  email_confirmation_required: "Du musst deine E-Mail bestätigen bevor du dich einloggen kannst. Bitte schau in deinem Spam Ordner nach falls nichts ankommen sollte."
   exit_full_screen: Vollbild beenden
   forgot_password: Passwort vergessen
-  forgot_password_help: Bitte gib deine E-mail ein damit wir dir ein neues Passwort senden können.
+  forgot_password_help: Bitte gib deine E-Mail ein damit wir dir ein neues Passwort senden können.
   forgot_password_link: Passwort vergessen?
   full_screen: Vollbild
   go_to: "Gehe zu {location}"
@@ -47,7 +47,7 @@ core:
   group_mod: Moderator
   group_mods: Moderatoren
   invalid_login: Login inkorrekt.
-  joined: "Registriert am {ago}"
+  joined: "Registriert: {ago}"
   load_more: Mehr laden
   log_in: Einloggen
   log_in_to_reply: Einloggen um zu antworten
@@ -62,7 +62,7 @@ core:
   online: Online
   original_post: Originale Nachricht
   password: Passwort
-  password_reset_email_sent: Wir haben dir eine E-mail geschickt mit der du dein Passwort zurücksetzen kannst. Bitte schaue in deinem Spam Ordner nach falls nichts ankommen sollte.
+  password_reset_email_sent: Wir haben dir eine E-Mail geschickt mit der du dein Passwort zurücksetzen kannst. Bitte schaue in deinem Spam Ordner nach falls nichts ankommen sollte.
   period_later: "{period} später"
   post_discussion: Diskussion posten
   post_edited: " {ago} von {username} geändert"
@@ -83,7 +83,7 @@ core:
   save_changes: Änderungen speichern
   search_all_discussions: 'Durchsuche alle Diskussionen nach "{query}"'
   search_forum: Forum durchsuchen
-  send_password_reset_email: Sende E-mail zum Passwort zurücksetzen
+  send_password_reset_email: Sende E-Mail zum Passwort zurücksetzen
   settings: Einstellungen
   sign_up: Registrieren
   sort_latest: Letzte


### PR DESCRIPTION
This fixes some mistakes in the translation.
Some of the month shortcuts were wrong. E.g. in german there is no shortcut for 'Juni' or 'Juli':
https://de.wikipedia.org/wiki/Monat#Kurzformen

Also it's called 'E-Mail' instead of 'e-mail', another common mistake (http://www.korrekturen.de/beliebte_fehler/email.shtml).

Another thing was the translation of 'Registriert am {time}'. I changed it to 'Registiert:', because 'Registriert am vor 2 Tagen' or something like that sounds really weird.
